### PR TITLE
upgrade to circleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,56 @@
+version: 2
+jobs:
+  lint:
+    working_directory: ~/workbench-tooling
+    docker:
+      - image: circleci/python:2.7
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps1-{{ .Branch }}-{{ checksum "setup.py" }}
+      - run:
+          command: |
+            python2 -m virtualenv venv
+            . venv/bin/activate
+            pip install setuptools-lint flake8
+            pip install .
+            pip uninstall -y workbench
+      - save_cache:
+          key: deps1-{{ .Branch }}-{{ checksum "setup.py" }}
+          paths:
+            - "venv"
+      - run:
+          command: |
+            . venv/bin/activate
+            python setup.py lint
+            flake8 cli
+  nosetests:
+    working_directory: ~/workbench-tooling
+    docker:
+      - image: circleci/python:2.7
+    steps:
+      - checkout
+      - restore_cache:
+          key: deps1-{{ .Branch }}-{{ checksum "setup.py" }}
+      - run:
+          command: |
+            python2 -m virtualenv venv
+            . venv/bin/activate
+            pip install nose
+            pip install .
+            pip uninstall -y workbench
+      - save_cache:
+          key: deps1-{{ .Branch }}-{{ checksum "setup.py" }}
+          paths:
+            - "venv"
+      - run:
+          command: |
+            . venv/bin/activate
+            python setup.py nosetests
+
+workflows:
+  version: 2
+  testing:
+    jobs:
+      - lint
+      - nosetests

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,0 @@
-dependencies:
-  post:
-    - pip install setuptools-lint flake8
-
-test:
-  override:
-    - python setup.py lint
-    - flake8 cli


### PR DESCRIPTION
Creating one `testing` workflow with two parallel steps:
  - `lint`: flake8 linting and setuptools lint
  - `nosetests`: runs the nose framework, no tests are present for now